### PR TITLE
Add basic auth forms and logic

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,72 +1,105 @@
 import { useEffect, useState } from "react";
 import { Header } from "./components/header";
 import { Tasks } from "./components/tasks";
+import { Login } from "./components/Login";
+import { Register } from "./components/Register";
 
-const API_URL = "https://65f019aada8c6584131ac3e0.mockapi.io/Todo/Stalin/Todo";
+const TASKS_API_URL = "https://65f019aada8c6584131ac3e0.mockapi.io/Todo/Stalin/Todo";
 
 function App() {
-
-  const [tasks, setTasks] = useState([])
+  const [tasks, setTasks] = useState([]);
+  const [user, setUser] = useState(() => {
+    const stored = localStorage.getItem("user");
+    return stored ? JSON.parse(stored) : null;
+  });
+  const [showRegister, setShowRegister] = useState(false);
 
   async function loadTasks() {
     try {
-      const response = await fetch(API_URL)
-      const data = await response.json()
-      setTasks(data)
+      const response = await fetch(TASKS_API_URL);
+      const data = await response.json();
+      setTasks(data);
     } catch (e) {
-      console.error("Failed to load tasks", e)
+      console.error("Failed to load tasks", e);
     }
   }
 
   useEffect(() => {
-    loadTasks()
-  }, [])
+    if (user) {
+      loadTasks();
+    }
+  }, [user]);
 
   async function addTask(taskText) {
     try {
-      const response = await fetch(API_URL, {
+      const response = await fetch(TASKS_API_URL, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ text: taskText, isCompleted: false })
-      })
-      const newTask = await response.json()
-      setTasks((prev) => [...prev, newTask])
+      });
+      const newTask = await response.json();
+      setTasks((prev) => [...prev, newTask]);
     } catch (e) {
-      console.error("Failed to add task", e)
+      console.error("Failed to add task", e);
     }
   }
 
   async function toggleTaskCompletedById(taskId) {
-    const taskToToggle = tasks.find((task) => task.id === taskId)
-    if (!taskToToggle) return
+    const taskToToggle = tasks.find((task) => task.id === taskId);
+    if (!taskToToggle) return;
     const updated = {
       ...taskToToggle,
       isCompleted: !taskToToggle.isCompleted
-    }
+    };
     try {
-      const response = await fetch(`${API_URL}/${taskId}`, {
+      const response = await fetch(`${TASKS_API_URL}/${taskId}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(updated)
-      })
-      const updatedTask = await response.json()
-      setTasks((prev) => prev.map((t) => (t.id === taskId ? updatedTask : t)))
+      });
+      const updatedTask = await response.json();
+      setTasks((prev) => prev.map((t) => (t.id === taskId ? updatedTask : t)));
     } catch (e) {
-      console.error("Failed to update task", e)
+      console.error("Failed to update task", e);
     }
   }
 
   async function deleteTaskById(taskId) {
     try {
-      await fetch(`${API_URL}/${taskId}`, { method: "DELETE" })
-      setTasks((prev) => prev.filter((task) => task.id !== taskId))
+      await fetch(`${TASKS_API_URL}/${taskId}`, { method: "DELETE" });
+      setTasks((prev) => prev.filter((task) => task.id !== taskId));
     } catch (e) {
-      console.error("Failed to delete task", e)
+      console.error("Failed to delete task", e);
     }
+  }
+
+  function handleLogin(u) {
+    setUser(u);
+    localStorage.setItem("user", JSON.stringify(u));
+  }
+
+  function handleRegister(u) {
+    setUser(u);
+    localStorage.setItem("user", JSON.stringify(u));
+  }
+
+  function handleLogout() {
+    setUser(null);
+    localStorage.removeItem("user");
+    setTasks([]);
+  }
+
+  if (!user) {
+    return showRegister ? (
+      <Register onRegister={handleRegister} onShowLogin={() => setShowRegister(false)} />
+    ) : (
+      <Login onLogin={handleLogin} onShowRegister={() => setShowRegister(true)} />
+    );
   }
 
   return (
     <>
+      <button onClick={handleLogout}>Logout</button>
       <Header onAddTask={addTask} />
       <Tasks
         tasks={tasks}
@@ -74,7 +107,7 @@ function App() {
         onDelete={deleteTaskById}
       />
     </>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -1,0 +1,46 @@
+/* eslint-disable react/prop-types */
+import { useState } from 'react';
+
+const USER_API_URL = "https://65f019aada8c6584131ac3e0.mockapi.io/Todo/Stalin/user";
+
+export function Login({ onLogin, onShowRegister }) {
+  const [name, setName] = useState('');
+  const [password, setPassword] = useState('');
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    try {
+      const response = await fetch(USER_API_URL);
+      const users = await response.json();
+      const found = users.find(
+        (u) => u.name === name && String(u.password) === String(password)
+      );
+      if (found) {
+        onLogin(found);
+      } else {
+        alert('Invalid credentials');
+      }
+    } catch (err) {
+      console.error('Login failed', err);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+      <input
+        type="text"
+        placeholder="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type="submit">Login</button>
+      <button type="button" onClick={onShowRegister}>Register</button>
+    </form>
+  );
+}

--- a/src/components/Register.jsx
+++ b/src/components/Register.jsx
@@ -1,0 +1,43 @@
+/* eslint-disable react/prop-types */
+import { useState } from 'react';
+
+const USER_API_URL = "https://65f019aada8c6584131ac3e0.mockapi.io/Todo/Stalin/user";
+
+export function Register({ onRegister, onShowLogin }) {
+  const [name, setName] = useState('');
+  const [password, setPassword] = useState('');
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    try {
+      const response = await fetch(USER_API_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, password })
+      });
+      const user = await response.json();
+      onRegister(user);
+    } catch (err) {
+      console.error('Registration failed', err);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+      <input
+        type="text"
+        placeholder="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type="submit">Register</button>
+      <button type="button" onClick={onShowLogin}>Back to Login</button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add `Login` and `Register` components
- store logged in user in state/localStorage
- show login/register forms when user not authenticated
- load todos after authentication

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68405f1591988324ab7f11f0b21fc4ab