### PR TITLE
Show logged-in user in header

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -99,8 +99,7 @@ function App() {
 
   return (
     <>
-      <button onClick={handleLogout}>Logout</button>
-      <Header onAddTask={addTask} />
+      <Header onAddTask={addTask} userName={user.name} onLogout={handleLogout} />
       <Tasks
         tasks={tasks}
         onComplete={toggleTaskCompletedById}

--- a/src/components/header/header.module.css
+++ b/src/components/header/header.module.css
@@ -10,6 +10,31 @@
     z-index: 2;
 }
 
+.userArea {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.user {
+    font-size: 1.4rem;
+    font-weight: 600;
+    color: #fff;
+}
+
+.logoutBtn {
+    background: #444444;
+    color: #fff;
+    border: none;
+    border-radius: 5px;
+    padding: 0.4rem 1rem;
+    font-size: 1.2rem;
+    cursor: pointer;
+}
+
 .newTaskForm {
     position: absolute;
     bottom: -2.7rem;

--- a/src/components/header/index.jsx
+++ b/src/components/header/index.jsx
@@ -4,7 +4,7 @@ import { AiOutlinePlusCircle } from "react-icons/ai";
 import styles from './header.module.css';
 import { useState } from 'react';
 
-export function Header({ onAddTask }) {
+export function Header({ onAddTask, userName, onLogout }) {
 
     const [text, setText] = useState('')
 
@@ -25,6 +25,14 @@ export function Header({ onAddTask }) {
     return (
         <header className={styles.header}>
             <img src={todo} alt="" />
+            <div className={styles.userArea}>
+                <span className={styles.user}>{userName}</span>
+                {onLogout && (
+                    <button type="button" onClick={onLogout} className={styles.logoutBtn}>
+                        Logout
+                    </button>
+                )}
+            </div>
 
             <form onSubmit={handleSubmit} className={styles.newTaskForm}>
                 <input type="text" placeholder='Add a New Task' value={text} onChange={onChangeTitle} />


### PR DESCRIPTION
## Summary
- show username in the header and add optional logout button
- style username section on the top right of the header
- pass username and logout handler from `App` to `Header`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684064f3f22c83248b75b72a35a3907e